### PR TITLE
Remove return outside of function as it is not es6 module compliant

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,27 +3,27 @@
 var $Map = typeof Map === 'function' && Map.prototype ? Map : null;
 var $Set = typeof Set === 'function' && Set.prototype ? Set : null;
 
+var exported;
+
 if (!$Map) {
 	// eslint-disable-next-line no-unused-vars
-	module.exports = function isMap(x) {
+	exported = function isMap(x) {
 		// `Map` is not present in this environment.
 		return false;
 	};
-	return;
 }
 
 var $mapHas = $Map ? Map.prototype.has : null;
 var $setHas = $Set ? Set.prototype.has : null;
-if (!$mapHas) {
+if (!exported && !$mapHas) {
 	// eslint-disable-next-line no-unused-vars
-	module.exports = function isMap(x) {
+	exported = function isMap(x) {
 		// `Map` does not have a `has` method
 		return false;
 	};
-	return;
 }
 
-module.exports = function isMap(x) {
+module.exports = exported || function isMap(x) {
 	if (!x || typeof x !== 'object') {
 		return false;
 	}


### PR DESCRIPTION
Since which-collection has been added to is-equal there's a lot of module dependant on is-map. According to https://github.com/babel/babel/issues/1298 returns outside of function are not es6 module compliant. So I submit this PR to avoid the return.

I changed the if to avoid the negative condition. Please give me some feedback if you're unhappy with anything. Thank you.